### PR TITLE
Multi-OS coverage command and CI test jobs

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -28,16 +28,16 @@ jobs:
       run: |
         black --check --diff --extend-exclude=versioneer.py .
 
-  build:
+  test:
 
     needs: lint
-    name: "Build ${{matrix.python-version}} (continue-on-error: ${{matrix.experimental}})"
-    runs-on: ${{ matrix.os }}
+    name: "Test ${{matrix.os}}, ${{matrix.python-version}} (continue-on-error: ${{matrix.experimental}})"
+    runs-on: ${{ matrix.os }}-latest
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu, windows, macos]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         include:
           - experimental: false

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -31,7 +31,7 @@ jobs:
   test:
 
     needs: lint
-    name: "Test ${{matrix.os}}, ${{matrix.python-version}} (continue-on-error: ${{matrix.experimental}})"
+    name: Test (${{ matrix.os }}, ${{ matrix.python-version }}, ${{ matrix.experimental }})
     runs-on: ${{ matrix.os }}-latest
     continue-on-error: ${{ matrix.experimental }}
     strategy:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -32,11 +32,12 @@ jobs:
 
     needs: lint
     name: "Build ${{matrix.python-version}} (continue-on-error: ${{matrix.experimental}})"
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: true
       matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         include:
           - experimental: false

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ python =
 
 [testenv]
 commands =
-  coverage run {envbindir}/pytest --doctest-glob='python_jsonschema_objects/*.md' {posargs}
+  coverage run -m pytest --doctest-glob='python_jsonschema_objects/*.md' {posargs}
   coverage xml --omit='*test*'
 deps =
   coverage


### PR DESCRIPTION
Like EliahKagan#1, this PR on my fork should remain a draft and should *not* be merged. It is for testing CI. The branch may end up being suitable for opening a PR on the upstream repository. Whether or not that is done, this PR can be closed when its purpose, in allowing CI results to be inspected within my fork, is finished.

This allows me to do some testing of an expanded CI matrix with multiple OSes, internal to my fork, to get my modifications in better shape before proposing them upstream.