### PR TITLE
Test on 3.12

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -37,10 +37,10 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
           - experimental: false
-          - python-version: "3.11"
+          - python-version: "3.12"
             experimental: true
 
     steps:
@@ -49,6 +49,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: ${{ matrix.experimental }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/development.txt
+++ b/development.txt
@@ -5,6 +5,5 @@ pyandoc
 pytest
 pytest-mock
 recommonmark
-setuptools;python_version>="3.12"
 sphinx
 sphinx-autobuild

--- a/development.txt
+++ b/development.txt
@@ -5,5 +5,6 @@ pyandoc
 pytest
 pytest-mock
 recommonmark
+setuptools;python_version>="3.12"
 sphinx
 sphinx-autobuild

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310,311}-jsonschema{23,24,25,26,30,40}-markdown{2,3}
+envlist = py{37,38,39,310,311,312}-jsonschema{23,24,25,26,30,40}-markdown{2,3}
 skip_missing_interpreters = true
 
 [gh-actions]
@@ -9,6 +9,7 @@ python =
   3.9: py39
   3.10: py310
   3.11: py311
+  3.12: py312
 
 [testenv]
 commands =
@@ -18,6 +19,7 @@ deps =
   coverage
   pytest
   pytest-mock
+  py312: setuptools
   jsonschema23: jsonschema~=2.3.0
   jsonschema24: jsonschema~=2.4.0
   jsonschema25: jsonschema~=2.5.0

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,6 @@ deps =
   coverage
   pytest
   pytest-mock
-  py312: setuptools
   jsonschema23: jsonschema~=2.3.0
   jsonschema24: jsonschema~=2.4.0
   jsonschema25: jsonschema~=2.5.0


### PR DESCRIPTION
Like EliahKagan#1 and EliahKagan#2, this PR on my fork should remain a draft and should *not* be merged. It is for testing CI. The branch may end up being suitable for opening a PR on the upstream repository. Whether or not that is done, this PR can be closed when its purpose, in allowing CI results to be inspected within my fork, is finished.

This adds Python 3.12 tox environments and CI test jobs. For purposes of testing, it also adds `setuptools` as an explicit test dependency on 3.12, but I don't think that's the best approach to dealing with `conftest.py`'s use of `pkg_resources`. I plan to add another commit to remove that explicit `setuptools` dependency, if I open a PR on the upstream repository.